### PR TITLE
Make lib flexible

### DIFF
--- a/ToopherDotNet/ToopherDotNet.cs
+++ b/ToopherDotNet/ToopherDotNet.cs
@@ -13,212 +13,230 @@ namespace Toopher
 	public class ToopherAPI
 	{
 		public const string DEFAULT_BASE_URL = "https://api.toopher.com/v1/";
-		
+
 		string consumerKey;
 		string consumerSecret;
-        string baseUrl;
+		string baseUrl;
 
 		// Create the ToopherAPI object tied to your requester credentials
 		// 
 		// Credentials are available on https://dev.toopher.com
-		public ToopherAPI (string consumerKey, string consumerSecret, string baseUrl = null)
+		public ToopherAPI(string consumerKey, string consumerSecret, string baseUrl = null)
 		{
 			this.consumerKey = consumerKey;
 			this.consumerSecret = consumerSecret;
-            if (baseUrl != null)
-            {
-                this.baseUrl = baseUrl;
-            }
-            else
-            {
-                this.baseUrl = ToopherAPI.DEFAULT_BASE_URL;
-            }
+			if (baseUrl != null)
+			{
+				this.baseUrl = baseUrl;
+			}
+			else
+			{
+				this.baseUrl = ToopherAPI.DEFAULT_BASE_URL;
+			}
 		}
 
 		// Pair your requester with a user's Toopher application
 		//
 		// Must provide a pairing request (generated on their phone) and
 		// the user's name
-		public PairingStatus Pair (string pairingPhrase, string userName, Dictionary<string, string> extras = null)
+		public PairingStatus Pair(string pairingPhrase, string userName, Dictionary<string, string> extras = null)
 		{
 			string endpoint = "pairings/create";
 
-			NameValueCollection parameters = new NameValueCollection ();
-			parameters.Add ("pairing_phrase", pairingPhrase);
-			parameters.Add ("user_name", userName);
+			NameValueCollection parameters = new NameValueCollection();
+			parameters.Add("pairing_phrase", pairingPhrase);
+			parameters.Add("user_name", userName);
 
-            if (extras != null)
-            {
-                foreach (KeyValuePair<string, string> kvp in extras)
-                {
-                    parameters.Add(kvp.Key, kvp.Value);
-                }
-            }
+			if (extras != null)
+			{
+				foreach (KeyValuePair<string, string> kvp in extras)
+				{
+					parameters.Add(kvp.Key, kvp.Value);
+				}
+			}
 
 
-			var json = post (endpoint, parameters);
+			var json = post(endpoint, parameters);
 			return PairingStatus.fromJson(json);
 		}
 
 		// Check on status of a pairing request
 		// 
 		// Must provide the ID returned when the pairing request was initiated
-		public PairingStatus GetPairingStatus (string pairingRequestId)
+		public PairingStatus GetPairingStatus(string pairingRequestId)
 		{
-			string endpoint = String.Format ("pairings/{0}", pairingRequestId);
+			string endpoint = String.Format("pairings/{0}", pairingRequestId);
 
-			var json = get (endpoint);
-			return PairingStatus.fromJson (json);
+			var json = get(endpoint);
+			return PairingStatus.fromJson(json);
 		}
 
 		// Authenticate an action with Toopher
 		//
 		// Provide pairing ID, a name for the terminal (displayed to user) and
 		// an option action name (displayed to user) [defaults to "log in"]
-		public AuthenticationStatus Authenticate (string pairingId, string terminalName, string actionName = null, Dictionary<string, string> extras = null)
+		public AuthenticationStatus Authenticate(string pairingId, string terminalName, string actionName = null, Dictionary<string, string> extras = null)
 		{
 			string endpoint = "authentication_requests/initiate";
-			
-			NameValueCollection parameters = new NameValueCollection ();
-			parameters.Add ("pairing_id", pairingId);
-			parameters.Add ("terminal_name", terminalName);
-			if (actionName != null) {
-				parameters.Add ("action_name", actionName);
-			}
-            if (extras != null)
-            {
-                foreach (KeyValuePair<string, string> kvp in extras)
-                {
-                    parameters.Add(kvp.Key, kvp.Value);
-                }
-            }
 
-			var json = post (endpoint, parameters);
-			return AuthenticationStatus.fromJson (json);
+			NameValueCollection parameters = new NameValueCollection();
+			parameters.Add("pairing_id", pairingId);
+			parameters.Add("terminal_name", terminalName);
+			if (actionName != null)
+			{
+				parameters.Add("action_name", actionName);
+			}
+			if (extras != null)
+			{
+				foreach (KeyValuePair<string, string> kvp in extras)
+				{
+					parameters.Add(kvp.Key, kvp.Value);
+				}
+			}
+
+			var json = post(endpoint, parameters);
+			return AuthenticationStatus.fromJson(json);
 		}
 
 		// Check on status of authentication request
 		//
 		// Provide authentication request ID returned when authentication request was
 		// started.
-		public AuthenticationStatus GetAuthenticationStatus (string authenticationRequestId)
+		public AuthenticationStatus GetAuthenticationStatus(string authenticationRequestId)
 		{
-			string endpoint = String.Format ("authentication_requests/{0}", authenticationRequestId);
+			string endpoint = String.Format("authentication_requests/{0}", authenticationRequestId);
 
-			var json = get (endpoint);
-			return AuthenticationStatus.fromJson (json);
+			var json = get(endpoint);
+			return AuthenticationStatus.fromJson(json);
 		}
-		
-		private JsonObject request (string method, string endpoint, NameValueCollection parameters = null)
+
+		private JsonObject request(string method, string endpoint, NameValueCollection parameters = null)
 		{
 			// Normalize method string
-			method = method.ToUpper ();
+			method = method.ToUpper();
 
 			// Build an empty collection for parameters (if necessary)
-			if (parameters == null) {
-				parameters = new NameValueCollection ();
+			if (parameters == null)
+			{
+				parameters = new NameValueCollection();
 			}
 
-			var client = OAuthRequest.ForRequestToken (this.consumerKey, this.consumerSecret);
+			var client = OAuthRequest.ForRequestToken(this.consumerKey, this.consumerSecret);
 			client.RequestUrl = this.baseUrl + endpoint;
 			client.Method = method;
-			
-			string auth = client.GetAuthorizationHeader (parameters);
+
+			string auth = client.GetAuthorizationHeader(parameters);
 			// FIXME: OAuth library puts extraneous comma at end, workaround: remove it if present
-			auth = auth.TrimEnd (new char[]{','});
-			
-			WebClient wClient = new WebClient ();
-			wClient.Headers.Add ("Authorization", auth);
-			if (parameters.Count > 0) {
+			auth = auth.TrimEnd(new char[] { ',' });
+
+			WebClient wClient = new WebClient();
+			wClient.Headers.Add("Authorization", auth);
+			if (parameters.Count > 0)
+			{
 				wClient.QueryString = parameters;
 			}
 
 			string response;
-			try {
-				if (method.Equals ("POST")) {
-					var responseArray = wClient.UploadValues (client.RequestUrl, client.Method, parameters);
-					response = Encoding.UTF8.GetString (responseArray);
-				} else {
-					response = wClient.DownloadString (client.RequestUrl);
+			try
+			{
+				if (method.Equals("POST"))
+				{
+					var responseArray = wClient.UploadValues(client.RequestUrl, client.Method, parameters);
+					response = Encoding.UTF8.GetString(responseArray);
 				}
-			} catch (WebException wex) {
+				else
+				{
+					response = wClient.DownloadString(client.RequestUrl);
+				}
+			}
+			catch (WebException wex)
+			{
 				string error_message;
-				using (Stream stream = wex.Response.GetResponseStream()) {
-					StreamReader reader = new StreamReader (stream, Encoding.UTF8);
-					error_message = reader.ReadToEnd ();
+				using (Stream stream = wex.Response.GetResponseStream())
+				{
+					StreamReader reader = new StreamReader(stream, Encoding.UTF8);
+					error_message = reader.ReadToEnd();
 				}
 
-				try {
+				try
+				{
 					// Attempt to parse JSON response
-					var json = (JsonObject)SimpleJson.SimpleJson.DeserializeObject (error_message);
-					error_message = (string)json ["error_message"];
-				} catch (Exception) { /* Ignore */ }
+					var json = (JsonObject)SimpleJson.SimpleJson.DeserializeObject(error_message);
+					error_message = (string)json["error_message"];
+				}
+				catch (Exception) { /* Ignore */ }
 
-				throw new RequestError (error_message, wex);
+				throw new RequestError(error_message, wex);
 			}
 
-			try {
-				return (JsonObject)SimpleJson.SimpleJson.DeserializeObject (response);
-			} catch (Exception ex) {
-				throw new RequestError ("Could not parse response", ex);
+			try
+			{
+				return (JsonObject)SimpleJson.SimpleJson.DeserializeObject(response);
+			}
+			catch (Exception ex)
+			{
+				throw new RequestError("Could not parse response", ex);
 			}
 		}
 
 		private JsonObject get(string endpoint, NameValueCollection parameters = null)
 		{
-			return request ("GET", endpoint, parameters);
+			return request("GET", endpoint, parameters);
 		}
 
-		private JsonObject post (string endpoint, NameValueCollection parameters = null)
+		private JsonObject post(string endpoint, NameValueCollection parameters = null)
 		{
-			return request ("POST", endpoint, parameters);
+			return request("POST", endpoint, parameters);
 		}
 	}
 
 	// Status information for a pairing request
 	public class PairingStatus : Dictionary<String, Object>
 	{
-        public string id
-        {
-            get { return (string)this["id"]; }
-        }
-        public string userId
-        {
-            get { return (string)((JsonObject)this["user"])["id"]; }
-        }
-        public string userName
-        {
-            get { return (string)((JsonObject)this["user"])["name"]; }
-        }
-        public bool enabled
-        {
-            get { return (bool)this["enabled"]; }
-        }
-
-		public override string ToString ()
+		public string id
 		{
-			return string.Format ("[PairingStatus: id={0}; userId={1}; userName={2}, enabled={3}]", id, userId, userName, enabled);
+			get { return (string)this["id"]; }
+		}
+		public string userId
+		{
+			get { return (string)((JsonObject)this["user"])["id"]; }
+		}
+		public string userName
+		{
+			get { return (string)((JsonObject)this["user"])["name"]; }
+		}
+		public bool enabled
+		{
+			get { return (bool)this["enabled"]; }
 		}
 
-		public static PairingStatus fromJson (JsonObject json)
+		public override string ToString()
 		{
-			try {
-                // validate that the json has the minimum keys we need
-                var id = (string)json["id"];
-				var enabled = (bool)json ["enabled"];
-				var user = (JsonObject)json ["user"];
-				var userId = (string)user ["id"];
-				var userName = (string)user ["name"];
+			return string.Format("[PairingStatus: id={0}; userId={1}; userName={2}, enabled={3}]", id, userId, userName, enabled);
+		}
 
-                // construct and return the result
-                PairingStatus result = new PairingStatus();
-                foreach (KeyValuePair<String, Object> kvp in json)
-                {
-                    result.Add(kvp.Key, kvp.Value);
-                }
-                return result;
-			} catch (Exception ex) {
-				throw new RequestError ("Could not parse pairing status from response", ex);
+		public static PairingStatus fromJson(JsonObject json)
+		{
+			try
+			{
+				// validate that the json has the minimum keys we need
+				var id = (string)json["id"];
+				var enabled = (bool)json["enabled"];
+				var user = (JsonObject)json["user"];
+				var userId = (string)user["id"];
+				var userName = (string)user["name"];
+
+				// construct and return the result
+				PairingStatus result = new PairingStatus();
+				foreach (KeyValuePair<String, Object> kvp in json)
+				{
+					result.Add(kvp.Key, kvp.Value);
+				}
+				return result;
+			}
+			catch (Exception ex)
+			{
+				throw new RequestError("Could not parse pairing status from response", ex);
 			}
 		}
 	}
@@ -226,65 +244,68 @@ namespace Toopher
 	// Status information for an authentication request
 	public class AuthenticationStatus : Dictionary<String, Object>
 	{
-        // convenience property accessors
-        public string id
-        {
-            get { return (string)this["id"]; }
-        }
-        public bool pending
-        {
-            get { return (bool)this["pending"]; }
-        }
-        public bool granted
-        {
-            get { return (bool)this["granted"]; }
-        }
-        public bool automated
-        {
-            get { return (bool)this["automated"]; }
-        }
-        public string reason
-        {
-            get { return (string)this["reason"]; }
-        }
-        public string terminalId
-        {
-            get { return (string)((JsonObject)this["terminal"])["id"]; }
-        }
-        public string terminalName
-        {
-            get { return (string)((JsonObject)this["terminal"])["name"]; }
-        }
-        
-        public override string ToString ()
+		// convenience property accessors
+		public string id
 		{
-			return string.Format ("[AuthenticationStatus: id={0}; pending={1}; granted={2}; automated={3}; reason={4}; terminalId={5}; terminalName={6}]", id, pending, granted, automated, reason, terminalId, terminalName);
+			get { return (string)this["id"]; }
+		}
+		public bool pending
+		{
+			get { return (bool)this["pending"]; }
+		}
+		public bool granted
+		{
+			get { return (bool)this["granted"]; }
+		}
+		public bool automated
+		{
+			get { return (bool)this["automated"]; }
+		}
+		public string reason
+		{
+			get { return (string)this["reason"]; }
+		}
+		public string terminalId
+		{
+			get { return (string)((JsonObject)this["terminal"])["id"]; }
+		}
+		public string terminalName
+		{
+			get { return (string)((JsonObject)this["terminal"])["name"]; }
 		}
 
-		public static AuthenticationStatus fromJson (JsonObject json)
+		public override string ToString()
 		{
-			try {
-                // validate that the json has the minimum keys we need
-				var id = (string)json ["id"];
-				var pending = (bool)json ["pending"];
-				var granted = (bool)json ["granted"];
-				var automated = (bool)json ["automated"];
-				var reason = (string)json ["reason"];
-				
-				var terminal = (JsonObject)json ["terminal"];
-				var terminalId = (string)terminal ["id"];
-				var terminalName = (string)terminal ["name"];
+			return string.Format("[AuthenticationStatus: id={0}; pending={1}; granted={2}; automated={3}; reason={4}; terminalId={5}; terminalName={6}]", id, pending, granted, automated, reason, terminalId, terminalName);
+		}
 
-                // construct and return the result
-                AuthenticationStatus result = new AuthenticationStatus();
-                foreach (KeyValuePair<String, Object> kvp in json)
-                {
-                    result.Add(kvp.Key, kvp.Value);
-                }
-                return result;
+		public static AuthenticationStatus fromJson(JsonObject json)
+		{
+			try
+			{
+				// validate that the json has the minimum keys we need
+				var id = (string)json["id"];
+				var pending = (bool)json["pending"];
+				var granted = (bool)json["granted"];
+				var automated = (bool)json["automated"];
+				var reason = (string)json["reason"];
 
-			} catch (Exception ex) {
-				throw new RequestError ("Could not parse authentication status from response", ex);
+				var terminal = (JsonObject)json["terminal"];
+				var terminalId = (string)terminal["id"];
+				var terminalName = (string)terminal["name"];
+
+				// construct and return the result
+				AuthenticationStatus result = new AuthenticationStatus();
+				foreach (KeyValuePair<String, Object> kvp in json)
+				{
+					result.Add(kvp.Key, kvp.Value);
+				}
+				return result;
+
+			}
+			catch (Exception ex)
+			{
+				throw new RequestError("Could not parse authentication status from response", ex);
 			}
 		}
 	}
@@ -292,9 +313,9 @@ namespace Toopher
 	// An exception class used to indicate an error in a request
 	public class RequestError : System.ApplicationException
 	{
-		public RequestError(string message) : base(message) {}
-		public RequestError(string message, System.Exception inner) : base(message, inner) {}
+		public RequestError(string message) : base(message) { }
+		public RequestError(string message, System.Exception inner) : base(message, inner) { }
 	}
-	
+
 }
 

--- a/ToopherDotNet/ToopherDotNet.cs
+++ b/ToopherDotNet/ToopherDotNet.cs
@@ -27,8 +27,7 @@ namespace Toopher
 			this.consumerSecret = consumerSecret;
 			if (baseUrl != null) {
 				this.baseUrl = baseUrl;
-			}
-			else {
+			} else {
 				this.baseUrl = ToopherAPI.DEFAULT_BASE_URL;
 			}
 		}
@@ -131,12 +130,10 @@ namespace Toopher
 				if (method.Equals ("POST")) {
 					var responseArray = wClient.UploadValues (client.RequestUrl, client.Method, parameters);
 					response = Encoding.UTF8.GetString (responseArray);
-				}
-				else {
+				} else {
 					response = wClient.DownloadString (client.RequestUrl);
 				}
-			}
-			catch (WebException wex) {
+			} catch (WebException wex) {
 				string error_message;
 				using (Stream stream = wex.Response.GetResponseStream ()) {
 					StreamReader reader = new StreamReader (stream, Encoding.UTF8);
@@ -147,16 +144,14 @@ namespace Toopher
 					// Attempt to parse JSON response
 					var json = (JsonObject)SimpleJson.SimpleJson.DeserializeObject (error_message);
 					error_message = (string)json["error_message"];
-				}
-				catch (Exception) { /* Ignore */ }
+				} catch (Exception) { /* Ignore */ }
 
 				throw new RequestError (error_message, wex);
 			}
 
 			try {
 				return (JsonObject)SimpleJson.SimpleJson.DeserializeObject (response);
-			}
-			catch (Exception ex) {
+			} catch (Exception ex) {
 				throw new RequestError ("Could not parse response", ex);
 			}
 		}
@@ -177,7 +172,8 @@ namespace Toopher
 	{
 		private IDictionary<string, Object> _dict;
 
-		public object this[string key] {
+		public object this[string key]
+		{
 			get
 			{
 				return _dict[key];
@@ -219,12 +215,11 @@ namespace Toopher
 				var user = (JsonObject)_dict["user"];
 				this.userId = (string)user["id"];
 				this.userName = (string)user["name"];
-			}
-			catch (Exception ex) {
+			} catch (Exception ex) {
 				throw new RequestError ("Could not parse pairing status from response", ex);
 			}
 		}
-		
+
 	}
 
 	// Status information for an authentication request
@@ -238,7 +233,7 @@ namespace Toopher
 				return _dict[key];
 			}
 		}
-		
+
 		public string id
 		{
 			get;
@@ -294,8 +289,7 @@ namespace Toopher
 				var terminal = (JsonObject)_dict["terminal"];
 				this.terminalId = (string)terminal["id"];
 				terminalName = (string)terminal["name"];
-			}
-			catch (Exception ex) {
+			} catch (Exception ex) {
 				throw new RequestError ("Could not parse authentication status from response", ex);
 			}
 		}

--- a/ToopherDotNet/ToopherDotNet.cs
+++ b/ToopherDotNet/ToopherDotNet.cs
@@ -51,9 +51,8 @@ namespace Toopher
 				}
 			}
 
-
 			var json = post (endpoint, parameters);
-			return PairingStatus.fromJson (json);
+			return new PairingStatus (json);
 		}
 
 		// Check on status of a pairing request
@@ -64,7 +63,7 @@ namespace Toopher
 			string endpoint = String.Format ("pairings/{0}", pairingRequestId);
 
 			var json = get (endpoint);
-			return PairingStatus.fromJson (json);
+			return new PairingStatus (json);
 		}
 
 		// Authenticate an action with Toopher
@@ -88,7 +87,7 @@ namespace Toopher
 			}
 
 			var json = post (endpoint, parameters);
-			return AuthenticationStatus.fromJson (json);
+			return new AuthenticationStatus (json);
 		}
 
 		// Check on status of authentication request
@@ -100,7 +99,7 @@ namespace Toopher
 			string endpoint = String.Format ("authentication_requests/{0}", authenticationRequestId);
 
 			var json = get (endpoint);
-			return AuthenticationStatus.fromJson (json);
+			return new AuthenticationStatus (json);
 		}
 
 		private JsonObject request (string method, string endpoint, NameValueCollection parameters = null)
@@ -174,23 +173,36 @@ namespace Toopher
 	}
 
 	// Status information for a pairing request
-	public class PairingStatus : Dictionary<String, Object>
+	public class PairingStatus
 	{
+		private IDictionary<string, Object> _dict;
+
+		public object this[string key] {
+			get
+			{
+				return _dict[key];
+			}
+		}
+
 		public string id
 		{
-			get { return (string)this["id"]; }
+			get;
+			private set;
 		}
 		public string userId
 		{
-			get { return (string)((JsonObject)this["user"])["id"]; }
+			get;
+			private set;
 		}
 		public string userName
 		{
-			get { return (string)((JsonObject)this["user"])["name"]; }
+			get;
+			private set;
 		}
 		public bool enabled
 		{
-			get { return (bool)this["enabled"]; }
+			get;
+			private set;
 		}
 
 		public override string ToString ()
@@ -198,60 +210,69 @@ namespace Toopher
 			return string.Format ("[PairingStatus: id={0}; userId={1}; userName={2}, enabled={3}]", id, userId, userName, enabled);
 		}
 
-		public static PairingStatus fromJson (JsonObject json)
+		public PairingStatus (IDictionary<string, object> _dict)
 		{
 			try {
-				// validate that the json has the minimum keys we need
-				var id = (string)json["id"];
-				var enabled = (bool)json["enabled"];
-				var user = (JsonObject)json["user"];
-				var userId = (string)user["id"];
-				var userName = (string)user["name"];
-
-				// construct and return the result
-				PairingStatus result = new PairingStatus ();
-				foreach (KeyValuePair<String, Object> kvp in json) {
-					result.Add (kvp.Key, kvp.Value);
-				}
-				return result;
+				this._dict = _dict;
+				this.id = (string)_dict["id"];
+				this.enabled = (bool)_dict["enabled"];
+				var user = (JsonObject)_dict["user"];
+				this.userId = (string)user["id"];
+				this.userName = (string)user["name"];
 			}
 			catch (Exception ex) {
 				throw new RequestError ("Could not parse pairing status from response", ex);
 			}
 		}
+		
 	}
 
 	// Status information for an authentication request
-	public class AuthenticationStatus : Dictionary<String, Object>
+	public class AuthenticationStatus
 	{
-		// convenience property accessors
+		private IDictionary<string, object> _dict;
+		public object this[string key]
+		{
+			get
+			{
+				return _dict[key];
+			}
+		}
+		
 		public string id
 		{
-			get { return (string)this["id"]; }
+			get;
+			private set;
 		}
 		public bool pending
 		{
-			get { return (bool)this["pending"]; }
+			get;
+			private set;
 		}
 		public bool granted
 		{
-			get { return (bool)this["granted"]; }
+			get;
+			private set;
 		}
 		public bool automated
 		{
-			get { return (bool)this["automated"]; }
+			get;
+			private set;
 		}
 		public string reason
 		{
-			get { return (string)this["reason"]; }
+			get;
+			private set;
 		}
 		public string terminalId
 		{
-			get { return (string)((JsonObject)this["terminal"])["id"]; }
+			get;
+			private set;
 		}
 		public string terminalName
 		{
-			get { return (string)((JsonObject)this["terminal"])["name"]; }
+			get;
+			private set;
 		}
 
 		public override string ToString ()
@@ -259,27 +280,20 @@ namespace Toopher
 			return string.Format ("[AuthenticationStatus: id={0}; pending={1}; granted={2}; automated={3}; reason={4}; terminalId={5}; terminalName={6}]", id, pending, granted, automated, reason, terminalId, terminalName);
 		}
 
-		public static AuthenticationStatus fromJson (JsonObject json)
+		public AuthenticationStatus (IDictionary<string, object> _dict)
 		{
+			this._dict = _dict;
 			try {
 				// validate that the json has the minimum keys we need
-				var id = (string)json["id"];
-				var pending = (bool)json["pending"];
-				var granted = (bool)json["granted"];
-				var automated = (bool)json["automated"];
-				var reason = (string)json["reason"];
+				this.id = (string)_dict["id"];
+				this.pending = (bool)_dict["pending"];
+				this.granted = (bool)_dict["granted"];
+				this.automated = (bool)_dict["automated"];
+				this.reason = (string)_dict["reason"];
 
-				var terminal = (JsonObject)json["terminal"];
-				var terminalId = (string)terminal["id"];
-				var terminalName = (string)terminal["name"];
-
-				// construct and return the result
-				AuthenticationStatus result = new AuthenticationStatus ();
-				foreach (KeyValuePair<String, Object> kvp in json) {
-					result.Add (kvp.Key, kvp.Value);
-				}
-				return result;
-
+				var terminal = (JsonObject)_dict["terminal"];
+				this.terminalId = (string)terminal["id"];
+				terminalName = (string)terminal["name"];
 			}
 			catch (Exception ex) {
 				throw new RequestError ("Could not parse authentication status from response", ex);

--- a/ToopherDotNet/ToopherDotNet.cs
+++ b/ToopherDotNet/ToopherDotNet.cs
@@ -21,7 +21,7 @@ namespace Toopher
 		// Create the ToopherAPI object tied to your requester credentials
 		// 
 		// Credentials are available on https://dev.toopher.com
-		public ToopherAPI(string consumerKey, string consumerSecret, string baseUrl = null)
+		public ToopherAPI (string consumerKey, string consumerSecret, string baseUrl = null)
 		{
 			this.consumerKey = consumerKey;
 			this.consumerSecret = consumerSecret;
@@ -37,7 +37,7 @@ namespace Toopher
 		//
 		// Must provide a pairing request (generated on their phone) and
 		// the user's name
-		public PairingStatus Pair(string pairingPhrase, string userName, Dictionary<string, string> extras = null)
+		public PairingStatus Pair (string pairingPhrase, string userName, Dictionary<string, string> extras = null)
 		{
 			string endpoint = "pairings/create";
 
@@ -59,7 +59,7 @@ namespace Toopher
 		// Check on status of a pairing request
 		// 
 		// Must provide the ID returned when the pairing request was initiated
-		public PairingStatus GetPairingStatus(string pairingRequestId)
+		public PairingStatus GetPairingStatus (string pairingRequestId)
 		{
 			string endpoint = String.Format ("pairings/{0}", pairingRequestId);
 
@@ -71,7 +71,7 @@ namespace Toopher
 		//
 		// Provide pairing ID, a name for the terminal (displayed to user) and
 		// an option action name (displayed to user) [defaults to "log in"]
-		public AuthenticationStatus Authenticate(string pairingId, string terminalName, string actionName = null, Dictionary<string, string> extras = null)
+		public AuthenticationStatus Authenticate (string pairingId, string terminalName, string actionName = null, Dictionary<string, string> extras = null)
 		{
 			string endpoint = "authentication_requests/initiate";
 
@@ -95,7 +95,7 @@ namespace Toopher
 		//
 		// Provide authentication request ID returned when authentication request was
 		// started.
-		public AuthenticationStatus GetAuthenticationStatus(string authenticationRequestId)
+		public AuthenticationStatus GetAuthenticationStatus (string authenticationRequestId)
 		{
 			string endpoint = String.Format ("authentication_requests/{0}", authenticationRequestId);
 
@@ -103,7 +103,7 @@ namespace Toopher
 			return AuthenticationStatus.fromJson (json);
 		}
 
-		private JsonObject request(string method, string endpoint, NameValueCollection parameters = null)
+		private JsonObject request (string method, string endpoint, NameValueCollection parameters = null)
 		{
 			// Normalize method string
 			method = method.ToUpper ();
@@ -162,12 +162,12 @@ namespace Toopher
 			}
 		}
 
-		private JsonObject get(string endpoint, NameValueCollection parameters = null)
+		private JsonObject get (string endpoint, NameValueCollection parameters = null)
 		{
 			return request ("GET", endpoint, parameters);
 		}
 
-		private JsonObject post(string endpoint, NameValueCollection parameters = null)
+		private JsonObject post (string endpoint, NameValueCollection parameters = null)
 		{
 			return request ("POST", endpoint, parameters);
 		}
@@ -193,12 +193,12 @@ namespace Toopher
 			get { return (bool)this["enabled"]; }
 		}
 
-		public override string ToString()
+		public override string ToString ()
 		{
 			return string.Format ("[PairingStatus: id={0}; userId={1}; userName={2}, enabled={3}]", id, userId, userName, enabled);
 		}
 
-		public static PairingStatus fromJson(JsonObject json)
+		public static PairingStatus fromJson (JsonObject json)
 		{
 			try {
 				// validate that the json has the minimum keys we need
@@ -254,12 +254,12 @@ namespace Toopher
 			get { return (string)((JsonObject)this["terminal"])["name"]; }
 		}
 
-		public override string ToString()
+		public override string ToString ()
 		{
 			return string.Format ("[AuthenticationStatus: id={0}; pending={1}; granted={2}; automated={3}; reason={4}; terminalId={5}; terminalName={6}]", id, pending, granted, automated, reason, terminalId, terminalName);
 		}
 
-		public static AuthenticationStatus fromJson(JsonObject json)
+		public static AuthenticationStatus fromJson (JsonObject json)
 		{
 			try {
 				// validate that the json has the minimum keys we need
@@ -290,8 +290,8 @@ namespace Toopher
 	// An exception class used to indicate an error in a request
 	public class RequestError : System.ApplicationException
 	{
-		public RequestError(string message) : base (message) { }
-		public RequestError(string message, System.Exception inner) : base (message, inner) { }
+		public RequestError (string message) : base (message) { }
+		public RequestError (string message, System.Exception inner) : base (message, inner) { }
 	}
 
 }

--- a/ToopherDotNet/ToopherDotNet.cs
+++ b/ToopherDotNet/ToopherDotNet.cs
@@ -25,12 +25,10 @@ namespace Toopher
 		{
 			this.consumerKey = consumerKey;
 			this.consumerSecret = consumerSecret;
-			if (baseUrl != null)
-			{
+			if (baseUrl != null) {
 				this.baseUrl = baseUrl;
 			}
-			else
-			{
+			else {
 				this.baseUrl = ToopherAPI.DEFAULT_BASE_URL;
 			}
 		}
@@ -43,21 +41,19 @@ namespace Toopher
 		{
 			string endpoint = "pairings/create";
 
-			NameValueCollection parameters = new NameValueCollection();
-			parameters.Add("pairing_phrase", pairingPhrase);
-			parameters.Add("user_name", userName);
+			NameValueCollection parameters = new NameValueCollection ();
+			parameters.Add ("pairing_phrase", pairingPhrase);
+			parameters.Add ("user_name", userName);
 
-			if (extras != null)
-			{
-				foreach (KeyValuePair<string, string> kvp in extras)
-				{
-					parameters.Add(kvp.Key, kvp.Value);
+			if (extras != null) {
+				foreach (KeyValuePair<string, string> kvp in extras) {
+					parameters.Add (kvp.Key, kvp.Value);
 				}
 			}
 
 
-			var json = post(endpoint, parameters);
-			return PairingStatus.fromJson(json);
+			var json = post (endpoint, parameters);
+			return PairingStatus.fromJson (json);
 		}
 
 		// Check on status of a pairing request
@@ -65,10 +61,10 @@ namespace Toopher
 		// Must provide the ID returned when the pairing request was initiated
 		public PairingStatus GetPairingStatus(string pairingRequestId)
 		{
-			string endpoint = String.Format("pairings/{0}", pairingRequestId);
+			string endpoint = String.Format ("pairings/{0}", pairingRequestId);
 
-			var json = get(endpoint);
-			return PairingStatus.fromJson(json);
+			var json = get (endpoint);
+			return PairingStatus.fromJson (json);
 		}
 
 		// Authenticate an action with Toopher
@@ -79,23 +75,20 @@ namespace Toopher
 		{
 			string endpoint = "authentication_requests/initiate";
 
-			NameValueCollection parameters = new NameValueCollection();
-			parameters.Add("pairing_id", pairingId);
-			parameters.Add("terminal_name", terminalName);
-			if (actionName != null)
-			{
-				parameters.Add("action_name", actionName);
+			NameValueCollection parameters = new NameValueCollection ();
+			parameters.Add ("pairing_id", pairingId);
+			parameters.Add ("terminal_name", terminalName);
+			if (actionName != null) {
+				parameters.Add ("action_name", actionName);
 			}
-			if (extras != null)
-			{
-				foreach (KeyValuePair<string, string> kvp in extras)
-				{
-					parameters.Add(kvp.Key, kvp.Value);
+			if (extras != null) {
+				foreach (KeyValuePair<string, string> kvp in extras) {
+					parameters.Add (kvp.Key, kvp.Value);
 				}
 			}
 
-			var json = post(endpoint, parameters);
-			return AuthenticationStatus.fromJson(json);
+			var json = post (endpoint, parameters);
+			return AuthenticationStatus.fromJson (json);
 		}
 
 		// Check on status of authentication request
@@ -104,89 +97,79 @@ namespace Toopher
 		// started.
 		public AuthenticationStatus GetAuthenticationStatus(string authenticationRequestId)
 		{
-			string endpoint = String.Format("authentication_requests/{0}", authenticationRequestId);
+			string endpoint = String.Format ("authentication_requests/{0}", authenticationRequestId);
 
-			var json = get(endpoint);
-			return AuthenticationStatus.fromJson(json);
+			var json = get (endpoint);
+			return AuthenticationStatus.fromJson (json);
 		}
 
 		private JsonObject request(string method, string endpoint, NameValueCollection parameters = null)
 		{
 			// Normalize method string
-			method = method.ToUpper();
+			method = method.ToUpper ();
 
 			// Build an empty collection for parameters (if necessary)
-			if (parameters == null)
-			{
-				parameters = new NameValueCollection();
+			if (parameters == null) {
+				parameters = new NameValueCollection ();
 			}
 
-			var client = OAuthRequest.ForRequestToken(this.consumerKey, this.consumerSecret);
+			var client = OAuthRequest.ForRequestToken (this.consumerKey, this.consumerSecret);
 			client.RequestUrl = this.baseUrl + endpoint;
 			client.Method = method;
 
-			string auth = client.GetAuthorizationHeader(parameters);
+			string auth = client.GetAuthorizationHeader (parameters);
 			// FIXME: OAuth library puts extraneous comma at end, workaround: remove it if present
-			auth = auth.TrimEnd(new char[] { ',' });
+			auth = auth.TrimEnd (new char[] { ',' });
 
-			WebClient wClient = new WebClient();
-			wClient.Headers.Add("Authorization", auth);
-			if (parameters.Count > 0)
-			{
+			WebClient wClient = new WebClient ();
+			wClient.Headers.Add ("Authorization", auth);
+			if (parameters.Count > 0) {
 				wClient.QueryString = parameters;
 			}
 
 			string response;
-			try
-			{
-				if (method.Equals("POST"))
-				{
-					var responseArray = wClient.UploadValues(client.RequestUrl, client.Method, parameters);
-					response = Encoding.UTF8.GetString(responseArray);
+			try {
+				if (method.Equals ("POST")) {
+					var responseArray = wClient.UploadValues (client.RequestUrl, client.Method, parameters);
+					response = Encoding.UTF8.GetString (responseArray);
 				}
-				else
-				{
-					response = wClient.DownloadString(client.RequestUrl);
+				else {
+					response = wClient.DownloadString (client.RequestUrl);
 				}
 			}
-			catch (WebException wex)
-			{
+			catch (WebException wex) {
 				string error_message;
-				using (Stream stream = wex.Response.GetResponseStream())
-				{
-					StreamReader reader = new StreamReader(stream, Encoding.UTF8);
-					error_message = reader.ReadToEnd();
+				using (Stream stream = wex.Response.GetResponseStream ()) {
+					StreamReader reader = new StreamReader (stream, Encoding.UTF8);
+					error_message = reader.ReadToEnd ();
 				}
 
-				try
-				{
+				try {
 					// Attempt to parse JSON response
-					var json = (JsonObject)SimpleJson.SimpleJson.DeserializeObject(error_message);
+					var json = (JsonObject)SimpleJson.SimpleJson.DeserializeObject (error_message);
 					error_message = (string)json["error_message"];
 				}
 				catch (Exception) { /* Ignore */ }
 
-				throw new RequestError(error_message, wex);
+				throw new RequestError (error_message, wex);
 			}
 
-			try
-			{
-				return (JsonObject)SimpleJson.SimpleJson.DeserializeObject(response);
+			try {
+				return (JsonObject)SimpleJson.SimpleJson.DeserializeObject (response);
 			}
-			catch (Exception ex)
-			{
-				throw new RequestError("Could not parse response", ex);
+			catch (Exception ex) {
+				throw new RequestError ("Could not parse response", ex);
 			}
 		}
 
 		private JsonObject get(string endpoint, NameValueCollection parameters = null)
 		{
-			return request("GET", endpoint, parameters);
+			return request ("GET", endpoint, parameters);
 		}
 
 		private JsonObject post(string endpoint, NameValueCollection parameters = null)
 		{
-			return request("POST", endpoint, parameters);
+			return request ("POST", endpoint, parameters);
 		}
 	}
 
@@ -212,13 +195,12 @@ namespace Toopher
 
 		public override string ToString()
 		{
-			return string.Format("[PairingStatus: id={0}; userId={1}; userName={2}, enabled={3}]", id, userId, userName, enabled);
+			return string.Format ("[PairingStatus: id={0}; userId={1}; userName={2}, enabled={3}]", id, userId, userName, enabled);
 		}
 
 		public static PairingStatus fromJson(JsonObject json)
 		{
-			try
-			{
+			try {
 				// validate that the json has the minimum keys we need
 				var id = (string)json["id"];
 				var enabled = (bool)json["enabled"];
@@ -227,16 +209,14 @@ namespace Toopher
 				var userName = (string)user["name"];
 
 				// construct and return the result
-				PairingStatus result = new PairingStatus();
-				foreach (KeyValuePair<String, Object> kvp in json)
-				{
-					result.Add(kvp.Key, kvp.Value);
+				PairingStatus result = new PairingStatus ();
+				foreach (KeyValuePair<String, Object> kvp in json) {
+					result.Add (kvp.Key, kvp.Value);
 				}
 				return result;
 			}
-			catch (Exception ex)
-			{
-				throw new RequestError("Could not parse pairing status from response", ex);
+			catch (Exception ex) {
+				throw new RequestError ("Could not parse pairing status from response", ex);
 			}
 		}
 	}
@@ -276,13 +256,12 @@ namespace Toopher
 
 		public override string ToString()
 		{
-			return string.Format("[AuthenticationStatus: id={0}; pending={1}; granted={2}; automated={3}; reason={4}; terminalId={5}; terminalName={6}]", id, pending, granted, automated, reason, terminalId, terminalName);
+			return string.Format ("[AuthenticationStatus: id={0}; pending={1}; granted={2}; automated={3}; reason={4}; terminalId={5}; terminalName={6}]", id, pending, granted, automated, reason, terminalId, terminalName);
 		}
 
 		public static AuthenticationStatus fromJson(JsonObject json)
 		{
-			try
-			{
+			try {
 				// validate that the json has the minimum keys we need
 				var id = (string)json["id"];
 				var pending = (bool)json["pending"];
@@ -295,17 +274,15 @@ namespace Toopher
 				var terminalName = (string)terminal["name"];
 
 				// construct and return the result
-				AuthenticationStatus result = new AuthenticationStatus();
-				foreach (KeyValuePair<String, Object> kvp in json)
-				{
-					result.Add(kvp.Key, kvp.Value);
+				AuthenticationStatus result = new AuthenticationStatus ();
+				foreach (KeyValuePair<String, Object> kvp in json) {
+					result.Add (kvp.Key, kvp.Value);
 				}
 				return result;
 
 			}
-			catch (Exception ex)
-			{
-				throw new RequestError("Could not parse authentication status from response", ex);
+			catch (Exception ex) {
+				throw new RequestError ("Could not parse authentication status from response", ex);
 			}
 		}
 	}
@@ -313,8 +290,8 @@ namespace Toopher
 	// An exception class used to indicate an error in a request
 	public class RequestError : System.ApplicationException
 	{
-		public RequestError(string message) : base(message) { }
-		public RequestError(string message, System.Exception inner) : base(message, inner) { }
+		public RequestError(string message) : base (message) { }
+		public RequestError(string message, System.Exception inner) : base (message, inner) { }
 	}
 
 }

--- a/ToopherDotNetDemo/ToopherDotNetDemo.cs
+++ b/ToopherDotNetDemo/ToopherDotNetDemo.cs
@@ -12,153 +12,131 @@ namespace Toopher
 
 		public static void Main(string[] args)
 		{
-			Console.WriteLine("======================================");
-			Console.WriteLine("Library Usage Demo");
-			Console.WriteLine("======================================");
-			Console.WriteLine("");
-			Console.WriteLine("Setup Credentials");
-			Console.WriteLine("--------------------------------------");
-			string consumerKey = System.Environment.GetEnvironmentVariable("TOOPHER_CONSUMER_KEY");
-			string consumerSecret = System.Environment.GetEnvironmentVariable("TOOPHER_CONSUMER_SECRET");
-			if ((consumerKey == null) || (consumerSecret == null))
-			{
-				Console.WriteLine("Enter your requester credentials (from https://dev.toopher.com).");
-				Console.WriteLine("Hint: set the TOOPHER_CONSUMER_SECRET and TOOPHER_CONSUMER_SECRET environment variables to avoid this prompt.");
-				Console.Write("Consumer key: ");
-				consumerKey = Console.ReadLine();
-				Console.Write("Consumer secret: ");
-				consumerSecret = Console.ReadLine();
+			Console.WriteLine ("======================================");
+			Console.WriteLine ("Library Usage Demo");
+			Console.WriteLine ("======================================");
+			Console.WriteLine ("");
+			Console.WriteLine ("Setup Credentials");
+			Console.WriteLine ("--------------------------------------");
+			string consumerKey = System.Environment.GetEnvironmentVariable ("TOOPHER_CONSUMER_KEY");
+			string consumerSecret = System.Environment.GetEnvironmentVariable ("TOOPHER_CONSUMER_SECRET");
+			if ((consumerKey == null) || (consumerSecret == null)) {
+				Console.WriteLine ("Enter your requester credentials (from https://dev.toopher.com).");
+				Console.WriteLine ("Hint: set the TOOPHER_CONSUMER_SECRET and TOOPHER_CONSUMER_SECRET environment variables to avoid this prompt.");
+				Console.Write ("Consumer key: ");
+				consumerKey = Console.ReadLine ();
+				Console.Write ("Consumer secret: ");
+				consumerSecret = Console.ReadLine ();
 			}
-			string baseUrl = System.Environment.GetEnvironmentVariable("TOOPHER_BASE_URL");
+			string baseUrl = System.Environment.GetEnvironmentVariable ("TOOPHER_BASE_URL");
 
-			api = new Toopher.ToopherAPI(consumerKey, consumerSecret, baseUrl);
+			api = new Toopher.ToopherAPI (consumerKey, consumerSecret, baseUrl);
 
 			string pairingId;
-			while (true)
-			{
+			while (true) {
 				string pairingPhrase;
-				while (true)
-				{
-					Console.WriteLine("Step 1: Pair requester with phone");
-					Console.WriteLine("--------------------------------------");
-					Console.WriteLine("Pairing phrases are generated on the mobile app");
-					Console.Write("Enter pairing phrase: ");
-					pairingPhrase = Console.ReadLine();
+				while (true) {
+					Console.WriteLine ("Step 1: Pair requester with phone");
+					Console.WriteLine ("--------------------------------------");
+					Console.WriteLine ("Pairing phrases are generated on the mobile app");
+					Console.Write ("Enter pairing phrase: ");
+					pairingPhrase = Console.ReadLine ();
 
-					if (pairingPhrase.Length == 0)
-					{
-						Console.WriteLine("Please enter a pairing phrase to continue");
+					if (pairingPhrase.Length == 0) {
+						Console.WriteLine ("Please enter a pairing phrase to continue");
 					}
-					else
-					{
+					else {
 						break;
 					}
 				}
 
-				Console.Write(String.Format("Enter a username for this pairing [{0}]: ", DEFAULT_USERNAME));
-				string userName = Console.ReadLine();
-				if (userName.Length == 0)
-				{
+				Console.Write (String.Format ("Enter a username for this pairing [{0}]: ", DEFAULT_USERNAME));
+				string userName = Console.ReadLine ();
+				if (userName.Length == 0) {
 					userName = DEFAULT_USERNAME;
 				}
 
-				Console.WriteLine("Sending pairing request...");
+				Console.WriteLine ("Sending pairing request...");
 
-				try
-				{
-					var pairingStatus = api.Pair(pairingPhrase, userName);
+				try {
+					var pairingStatus = api.Pair (pairingPhrase, userName);
 					pairingId = pairingStatus.id;
 					break;
 				}
-				catch (RequestError err)
-				{
-					System.Console.WriteLine(String.Format("The pairing phrase was not accepted (reason:{0})", err.Message));
+				catch (RequestError err) {
+					System.Console.WriteLine (String.Format ("The pairing phrase was not accepted (reason:{0})", err.Message));
 				}
 			}
 
-			while (true)
-			{
-				Console.WriteLine("Authorize pairing on phone and then press return to continue.");
-				Console.ReadLine();
-				Console.WriteLine("Checking status of pairing request...");
+			while (true) {
+				Console.WriteLine ("Authorize pairing on phone and then press return to continue.");
+				Console.ReadLine ();
+				Console.WriteLine ("Checking status of pairing request...");
 
-				try
-				{
-					var pairingStatus = api.GetPairingStatus(pairingId);
-					if (pairingStatus.enabled)
-					{
-						Console.WriteLine("Pairing complete");
+				try {
+					var pairingStatus = api.GetPairingStatus (pairingId);
+					if (pairingStatus.enabled) {
+						Console.WriteLine ("Pairing complete");
 						break;
 					}
-					else
-					{
-						Console.WriteLine("The pairing has not been authorized by the phone yet.");
+					else {
+						Console.WriteLine ("The pairing has not been authorized by the phone yet.");
 					}
 				}
-				catch (RequestError err)
-				{
-					Console.WriteLine(String.Format("Could not check pairing status (reason:{0})", err.Message));
+				catch (RequestError err) {
+					Console.WriteLine (String.Format ("Could not check pairing status (reason:{0})", err.Message));
 				}
 			}
 
-			while (true)
-			{
-				Console.WriteLine("Step 2: Authenticate log in");
-				Console.WriteLine("--------------------------------------");
-				Console.Write(String.Format("Enter a terminal name for this authentication request [\"{0}\"]: ", DEFAULT_TERMINAL_NAME));
-				string terminalName = Console.ReadLine();
-				if (terminalName.Length == 0)
-				{
+			while (true) {
+				Console.WriteLine ("Step 2: Authenticate log in");
+				Console.WriteLine ("--------------------------------------");
+				Console.Write (String.Format ("Enter a terminal name for this authentication request [\"{0}\"]: ", DEFAULT_TERMINAL_NAME));
+				string terminalName = Console.ReadLine ();
+				if (terminalName.Length == 0) {
 					terminalName = DEFAULT_TERMINAL_NAME;
 				}
 
-				Console.WriteLine("Sending authentication request...");
+				Console.WriteLine ("Sending authentication request...");
 
 				string requestId;
-				try
-				{
-					var requestStatus = api.Authenticate(pairingId, terminalName);
+				try {
+					var requestStatus = api.Authenticate (pairingId, terminalName);
 					requestId = requestStatus.id;
 				}
-				catch (RequestError err)
-				{
-					Console.WriteLine(String.Format("Error initiating authentication (reason:{0})", err.Message));
+				catch (RequestError err) {
+					Console.WriteLine (String.Format ("Error initiating authentication (reason:{0})", err.Message));
 					continue;
 				}
 
-				while (true)
-				{
-					Console.WriteLine("Respond to authentication request on phone and then press return to continue.");
-					Console.ReadLine();
-					Console.WriteLine("Checking status of authentication request...");
+				while (true) {
+					Console.WriteLine ("Respond to authentication request on phone and then press return to continue.");
+					Console.ReadLine ();
+					Console.WriteLine ("Checking status of authentication request...");
 
 					AuthenticationStatus requestStatus;
-					try
-					{
-						requestStatus = api.GetAuthenticationStatus(requestId);
+					try {
+						requestStatus = api.GetAuthenticationStatus (requestId);
 					}
-					catch (RequestError err)
-					{
-						Console.WriteLine(String.Format("Could not check authentication status (reason:{0})", err.Message));
+					catch (RequestError err) {
+						Console.WriteLine (String.Format ("Could not check authentication status (reason:{0})", err.Message));
 						continue;
 					}
 
-					if (requestStatus.pending)
-					{
-						Console.WriteLine("The authentication request has not received a response from the phone yet.");
+					if (requestStatus.pending) {
+						Console.WriteLine ("The authentication request has not received a response from the phone yet.");
 					}
-					else
-					{
+					else {
 						string automation = requestStatus.automated ? "automatically " : "";
 						string result = requestStatus.granted ? "granted" : "denied";
-						Console.WriteLine("The request was " + automation + result + "!");
-						Console.WriteLine("This request " + ((bool)requestStatus["totp_valid"] ? "had" : "DID NOT HAVE") + " a valid authenticator OTP.");
+						Console.WriteLine ("The request was " + automation + result + "!");
+						Console.WriteLine ("This request " + ((bool)requestStatus["totp_valid"] ? "had" : "DID NOT HAVE") + " a valid authenticator OTP.");
 						break;
 					}
 				}
 
-				Console.WriteLine("Press return to authenticate again, or Ctrl-C to exit");
-				Console.ReadLine();
+				Console.WriteLine ("Press return to authenticate again, or Ctrl-C to exit");
+				Console.ReadLine ();
 			}
 		}
 	}

--- a/ToopherDotNetDemo/ToopherDotNetDemo.cs
+++ b/ToopherDotNetDemo/ToopherDotNetDemo.cs
@@ -10,7 +10,7 @@ namespace Toopher
 
 		public static ToopherAPI api;
 
-		public static void Main(string[] args)
+		public static void Main (string[] args)
 		{
 			Console.WriteLine ("======================================");
 			Console.WriteLine ("Library Usage Demo");

--- a/ToopherDotNetDemo/ToopherDotNetDemo.cs
+++ b/ToopherDotNetDemo/ToopherDotNetDemo.cs
@@ -44,8 +44,7 @@ namespace Toopher
 
 					if (pairingPhrase.Length == 0) {
 						Console.WriteLine ("Please enter a pairing phrase to continue");
-					}
-					else {
+					} else {
 						break;
 					}
 				}
@@ -62,8 +61,7 @@ namespace Toopher
 					var pairingStatus = api.Pair (pairingPhrase, userName);
 					pairingId = pairingStatus.id;
 					break;
-				}
-				catch (RequestError err) {
+				} catch (RequestError err) {
 					System.Console.WriteLine (String.Format ("The pairing phrase was not accepted (reason:{0})", err.Message));
 				}
 			}
@@ -78,12 +76,10 @@ namespace Toopher
 					if (pairingStatus.enabled) {
 						Console.WriteLine ("Pairing complete");
 						break;
-					}
-					else {
+					} else {
 						Console.WriteLine ("The pairing has not been authorized by the phone yet.");
 					}
-				}
-				catch (RequestError err) {
+				} catch (RequestError err) {
 					Console.WriteLine (String.Format ("Could not check pairing status (reason:{0})", err.Message));
 				}
 			}
@@ -103,8 +99,7 @@ namespace Toopher
 				try {
 					var requestStatus = api.Authenticate (pairingId, terminalName);
 					requestId = requestStatus.id;
-				}
-				catch (RequestError err) {
+				} catch (RequestError err) {
 					Console.WriteLine (String.Format ("Error initiating authentication (reason:{0})", err.Message));
 					continue;
 				}
@@ -117,16 +112,14 @@ namespace Toopher
 					AuthenticationStatus requestStatus;
 					try {
 						requestStatus = api.GetAuthenticationStatus (requestId);
-					}
-					catch (RequestError err) {
+					} catch (RequestError err) {
 						Console.WriteLine (String.Format ("Could not check authentication status (reason:{0})", err.Message));
 						continue;
 					}
 
 					if (requestStatus.pending) {
 						Console.WriteLine ("The authentication request has not received a response from the phone yet.");
-					}
-					else {
+					} else {
 						string automation = requestStatus.automated ? "automatically " : "";
 						string result = requestStatus.granted ? "granted" : "denied";
 						Console.WriteLine ("The request was " + automation + result + "!");

--- a/ToopherDotNetDemo/ToopherDotNetDemo.cs
+++ b/ToopherDotNetDemo/ToopherDotNetDemo.cs
@@ -10,121 +10,149 @@ namespace Toopher
 
 		public static ToopherAPI api;
 
-		public static void Main (string[] args)
+		public static void Main(string[] args)
 		{
-			Console.WriteLine ("======================================");
-			Console.WriteLine ("Library Usage Demo");
-			Console.WriteLine ("======================================");
-			Console.WriteLine ("");
-			Console.WriteLine ("Setup Credentials");
-			Console.WriteLine ("--------------------------------------");
-            string consumerKey = System.Environment.GetEnvironmentVariable("TOOPHER_CONSUMER_KEY");
-            string consumerSecret = System.Environment.GetEnvironmentVariable("TOOPHER_CONSUMER_SECRET");
-            if ((consumerKey == null) || (consumerSecret == null))
-            {
-                Console.WriteLine("Enter your requester credentials (from https://dev.toopher.com).");
-                Console.WriteLine("Hint: set the TOOPHER_CONSUMER_SECRET and TOOPHER_CONSUMER_SECRET environment variables to avoid this prompt.");
-                Console.Write("Consumer key: ");
-                consumerKey = Console.ReadLine();
-                Console.Write("Consumer secret: ");
-                consumerSecret = Console.ReadLine();
-            }
-            string baseUrl = System.Environment.GetEnvironmentVariable("TOOPHER_BASE_URL");
-			
-			api = new Toopher.ToopherAPI (consumerKey, consumerSecret, baseUrl);
+			Console.WriteLine("======================================");
+			Console.WriteLine("Library Usage Demo");
+			Console.WriteLine("======================================");
+			Console.WriteLine("");
+			Console.WriteLine("Setup Credentials");
+			Console.WriteLine("--------------------------------------");
+			string consumerKey = System.Environment.GetEnvironmentVariable("TOOPHER_CONSUMER_KEY");
+			string consumerSecret = System.Environment.GetEnvironmentVariable("TOOPHER_CONSUMER_SECRET");
+			if ((consumerKey == null) || (consumerSecret == null))
+			{
+				Console.WriteLine("Enter your requester credentials (from https://dev.toopher.com).");
+				Console.WriteLine("Hint: set the TOOPHER_CONSUMER_SECRET and TOOPHER_CONSUMER_SECRET environment variables to avoid this prompt.");
+				Console.Write("Consumer key: ");
+				consumerKey = Console.ReadLine();
+				Console.Write("Consumer secret: ");
+				consumerSecret = Console.ReadLine();
+			}
+			string baseUrl = System.Environment.GetEnvironmentVariable("TOOPHER_BASE_URL");
+
+			api = new Toopher.ToopherAPI(consumerKey, consumerSecret, baseUrl);
 
 			string pairingId;
-			while (true) {
+			while (true)
+			{
 				string pairingPhrase;
-				while (true) {
-					Console.WriteLine ("Step 1: Pair requester with phone");
-					Console.WriteLine ("--------------------------------------");
-					Console.WriteLine ("Pairing phrases are generated on the mobile app");
-					Console.Write ("Enter pairing phrase: ");
-					pairingPhrase = Console.ReadLine ();
+				while (true)
+				{
+					Console.WriteLine("Step 1: Pair requester with phone");
+					Console.WriteLine("--------------------------------------");
+					Console.WriteLine("Pairing phrases are generated on the mobile app");
+					Console.Write("Enter pairing phrase: ");
+					pairingPhrase = Console.ReadLine();
 
-					if (pairingPhrase.Length == 0) {
-						Console.WriteLine ("Please enter a pairing phrase to continue");
-					} else {
+					if (pairingPhrase.Length == 0)
+					{
+						Console.WriteLine("Please enter a pairing phrase to continue");
+					}
+					else
+					{
 						break;
 					}
 				}
 
-				Console.Write (String.Format ("Enter a username for this pairing [{0}]: ", DEFAULT_USERNAME));
-				string userName = Console.ReadLine ();
-				if (userName.Length == 0) {
+				Console.Write(String.Format("Enter a username for this pairing [{0}]: ", DEFAULT_USERNAME));
+				string userName = Console.ReadLine();
+				if (userName.Length == 0)
+				{
 					userName = DEFAULT_USERNAME;
 				}
 
-				Console.WriteLine ("Sending pairing request...");
+				Console.WriteLine("Sending pairing request...");
 
-				try {
-					var pairingStatus = api.Pair (pairingPhrase, userName);
+				try
+				{
+					var pairingStatus = api.Pair(pairingPhrase, userName);
 					pairingId = pairingStatus.id;
 					break;
-				} catch (RequestError err) {
-					System.Console.WriteLine (String.Format ("The pairing phrase was not accepted (reason:{0})", err.Message));
+				}
+				catch (RequestError err)
+				{
+					System.Console.WriteLine(String.Format("The pairing phrase was not accepted (reason:{0})", err.Message));
 				}
 			}
 
-			while (true) {
-				Console.WriteLine ("Authorize pairing on phone and then press return to continue.");
-				Console.ReadLine ();
-				Console.WriteLine ("Checking status of pairing request...");
+			while (true)
+			{
+				Console.WriteLine("Authorize pairing on phone and then press return to continue.");
+				Console.ReadLine();
+				Console.WriteLine("Checking status of pairing request...");
 
-				try {
-					var pairingStatus = api.GetPairingStatus (pairingId);
-					if (pairingStatus.enabled) {
-						Console.WriteLine ("Pairing complete");
+				try
+				{
+					var pairingStatus = api.GetPairingStatus(pairingId);
+					if (pairingStatus.enabled)
+					{
+						Console.WriteLine("Pairing complete");
 						break;
-					} else {
-						Console.WriteLine ("The pairing has not been authorized by the phone yet.");
 					}
-				} catch (RequestError err) {
-					Console.WriteLine (String.Format("Could not check pairing status (reason:{0})", err.Message));
+					else
+					{
+						Console.WriteLine("The pairing has not been authorized by the phone yet.");
+					}
+				}
+				catch (RequestError err)
+				{
+					Console.WriteLine(String.Format("Could not check pairing status (reason:{0})", err.Message));
 				}
 			}
 
-			while (true) {
-				Console.WriteLine ("Step 2: Authenticate log in");
-				Console.WriteLine ("--------------------------------------");
-				Console.Write (String.Format ("Enter a terminal name for this authentication request [\"{0}\"]: ", DEFAULT_TERMINAL_NAME));
-				string terminalName = Console.ReadLine ();
-				if (terminalName.Length == 0) {
+			while (true)
+			{
+				Console.WriteLine("Step 2: Authenticate log in");
+				Console.WriteLine("--------------------------------------");
+				Console.Write(String.Format("Enter a terminal name for this authentication request [\"{0}\"]: ", DEFAULT_TERMINAL_NAME));
+				string terminalName = Console.ReadLine();
+				if (terminalName.Length == 0)
+				{
 					terminalName = DEFAULT_TERMINAL_NAME;
 				}
 
-				Console.WriteLine ("Sending authentication request...");
+				Console.WriteLine("Sending authentication request...");
 
 				string requestId;
-				try {
-					var requestStatus = api.Authenticate (pairingId, terminalName);
+				try
+				{
+					var requestStatus = api.Authenticate(pairingId, terminalName);
 					requestId = requestStatus.id;
-				} catch (RequestError err) {
+				}
+				catch (RequestError err)
+				{
 					Console.WriteLine(String.Format("Error initiating authentication (reason:{0})", err.Message));
 					continue;
 				}
 
-				while (true) {
-					Console.WriteLine ("Respond to authentication request on phone and then press return to continue.");
-					Console.ReadLine ();
-					Console.WriteLine ("Checking status of authentication request...");
+				while (true)
+				{
+					Console.WriteLine("Respond to authentication request on phone and then press return to continue.");
+					Console.ReadLine();
+					Console.WriteLine("Checking status of authentication request...");
 
 					AuthenticationStatus requestStatus;
-					try {
-						requestStatus = api.GetAuthenticationStatus (requestId);
-					} catch (RequestError err) {
-						Console.WriteLine (String.Format("Could not check authentication status (reason:{0})", err.Message));
+					try
+					{
+						requestStatus = api.GetAuthenticationStatus(requestId);
+					}
+					catch (RequestError err)
+					{
+						Console.WriteLine(String.Format("Could not check authentication status (reason:{0})", err.Message));
 						continue;
 					}
 
-					if (requestStatus.pending) {
-						Console.WriteLine ("The authentication request has not received a response from the phone yet.");
-					} else {
+					if (requestStatus.pending)
+					{
+						Console.WriteLine("The authentication request has not received a response from the phone yet.");
+					}
+					else
+					{
 						string automation = requestStatus.automated ? "automatically " : "";
 						string result = requestStatus.granted ? "granted" : "denied";
-						Console.WriteLine ("The request was " + automation + result + "!");
-                        Console.WriteLine("This request " + ((bool)requestStatus["totp_valid"] ? "had" : "DID NOT HAVE") + " a valid authenticator OTP.");
+						Console.WriteLine("The request was " + automation + result + "!");
+						Console.WriteLine("This request " + ((bool)requestStatus["totp_valid"] ? "had" : "DID NOT HAVE") + " a valid authenticator OTP.");
 						break;
 					}
 				}

--- a/ToopherDotNetDemo/ToopherDotNetDemo.cs
+++ b/ToopherDotNetDemo/ToopherDotNetDemo.cs
@@ -18,13 +18,20 @@ namespace Toopher
 			Console.WriteLine ("");
 			Console.WriteLine ("Setup Credentials");
 			Console.WriteLine ("--------------------------------------");
-			Console.WriteLine ("Enter your requester credentials (from https://dev.toopher.com)");
-			Console.Write ("Consumer key: "); 
-			string consumerKey = Console.ReadLine ();
-			Console.Write ("Consumer secret: ");
-			string consumerSecret = Console.ReadLine ();
-
-			api = new Toopher.ToopherAPI (consumerKey, consumerSecret);
+            string consumerKey = System.Environment.GetEnvironmentVariable("TOOPHER_CONSUMER_KEY");
+            string consumerSecret = System.Environment.GetEnvironmentVariable("TOOPHER_CONSUMER_SECRET");
+            if ((consumerKey == null) || (consumerSecret == null))
+            {
+                Console.WriteLine("Enter your requester credentials (from https://dev.toopher.com).");
+                Console.WriteLine("Hint: set the TOOPHER_CONSUMER_SECRET and TOOPHER_CONSUMER_SECRET environment variables to avoid this prompt.");
+                Console.Write("Consumer key: ");
+                consumerKey = Console.ReadLine();
+                Console.Write("Consumer secret: ");
+                consumerSecret = Console.ReadLine();
+            }
+            string baseUrl = System.Environment.GetEnvironmentVariable("TOOPHER_BASE_URL");
+			
+			api = new Toopher.ToopherAPI (consumerKey, consumerSecret, baseUrl);
 
 			string pairingId;
 			while (true) {
@@ -117,6 +124,7 @@ namespace Toopher
 						string automation = requestStatus.automated ? "automatically " : "";
 						string result = requestStatus.granted ? "granted" : "denied";
 						Console.WriteLine ("The request was " + automation + result + "!");
+                        Console.WriteLine("This request " + ((bool)requestStatus["totp_valid"] ? "had" : "DID NOT HAVE") + " a valid authenticator OTP.");
 						break;
 					}
 				}


### PR DESCRIPTION
This PR allows the toopher .Net client library to support future fields returned by the API without modification.  The basic fields for each response type are still supported as first-class properties of the response object.  However, the response objects are also now indexable by field name so library consumers can access fields that are provided by the API endpoint, but not specifically supported by this library.

To access the basic fields supported as properties, just refer to them as usual:

``` C#
PairingStatus pairing = api.GetPairingStatus(pairingId);
if (pairing.enabled) { ... }
```

To access fields that are not specifically validated by the library, you can index the Status object as if it were a read-only `IDictionary<string, object>`:

``` C#
AuthenticationStatus auth = api.GetAutomationStatus(requestId);
if ((bool)auth["totp_valid"]) { ... }
```

Nested objects in the api response can be accessed as well:

``` C#
AuthenticationStatus auth = api.GetAutomationStatus(requestId);
Asssert.AreEqual(auth.terminalName, (string)((IDictionary<string, object>)auth["terminal"])["name"])
```
