### PR TITLE
Add version constant and test it

### DIFF
--- a/ToopherDotNet/ToopherDotNet.cs
+++ b/ToopherDotNet/ToopherDotNet.cs
@@ -12,6 +12,7 @@ namespace Toopher
 {
 	public class ToopherAPI
 	{
+		public const string VERSION = "1.0.0";
 		public const string DEFAULT_BASE_URL = "https://api.toopher.com/v1/";
 
 		string consumerKey;

--- a/ToopherDotNetTests/ToopherDotNetTests.cs
+++ b/ToopherDotNetTests/ToopherDotNetTests.cs
@@ -1,4 +1,5 @@
 using System;
+using Toopher;
 using NUnit.Framework;
 
 namespace ToopherDotNetTests
@@ -10,6 +11,24 @@ namespace ToopherDotNetTests
 		public void SimpleTest ()
 		{
 			Assert.AreEqual(1, 1);
+		}
+		[Test()]
+		public void ToopherVersionTest ()
+		{
+			Assert.IsTrue(ToopherAPI.VERSION is string);
+			string[] strs = ToopherAPI.VERSION.Split('.');
+			int major = int.Parse(strs[0]);
+			int minor = int.Parse(strs[1]);
+			int patchLevel = int.Parse(strs[2]);
+			Assert.IsTrue(major >= 1);
+			Assert.IsTrue(minor >= 0);
+			Assert.IsTrue(patchLevel >= 0);
+		}
+		[Test()]
+		public void ToopherBaseUrlTest ()
+		{
+			Assert.IsTrue(ToopherAPI.DEFAULT_BASE_URL is string);
+			Assert.IsTrue(System.Uri.IsWellFormedUriString(ToopherAPI.DEFAULT_BASE_URL, System.UriKind.Absolute));
 		}
 	}
 }


### PR DESCRIPTION
This pull request adds a `VERSION` constant to the library. I also wrote a test to ensure that the `VERSION` is a valid version string and that the `DEFAULT_BASE_URL` is a valid URL.
