### PR TITLE
Fix for NullReferenceException thrown when server is unavailable

### DIFF
--- a/ToopherDotNet/ToopherDotNet.cs
+++ b/ToopherDotNet/ToopherDotNet.cs
@@ -252,31 +252,35 @@ namespace Toopher
 						response = wClient.DownloadString (client.RequestUrl);
 					}
 				} catch (WebException wex) {
-					IHttpWebResponse httpResp = HttpWebResponseWrapper.create(wex.Response);
-					string error_message;
-					using (Stream stream = httpResp.GetResponseStream ()) {
-						StreamReader reader = new StreamReader (stream, Encoding.UTF8);
-						error_message = reader.ReadToEnd ();
-					}
-
-					String statusLine = httpResp.StatusCode.ToString () + " : " + httpResp.StatusDescription;
-
-					if (String.IsNullOrEmpty (error_message)) {
-						throw new RequestError (statusLine);
-					} else {
-
-						try {
-							// Attempt to parse JSON response
-							var json = (JsonObject)SimpleJson.SimpleJson.DeserializeObject (error_message);
-							parseRequestError (json);
-						} catch (RequestError e) {
-							throw e;
-						} catch (Exception) {
-							throw new RequestError (statusLine + " : " + error_message);
+					if (wex.Response != null) {
+						IHttpWebResponse httpResp = HttpWebResponseWrapper.create(wex.Response);
+						string error_message;
+						using (Stream stream = httpResp.GetResponseStream ()) {
+							StreamReader reader = new StreamReader (stream, Encoding.UTF8);
+							error_message = reader.ReadToEnd ();
 						}
-					}
 
-					throw new RequestError (error_message, wex);
+						String statusLine = httpResp.StatusCode.ToString () + " : " + httpResp.StatusDescription;
+
+						if (String.IsNullOrEmpty (error_message)) {
+							throw new RequestError (statusLine);
+						} else {
+
+							try {
+								// Attempt to parse JSON response
+								var json = (JsonObject)SimpleJson.SimpleJson.DeserializeObject (error_message);
+								parseRequestError (json);
+							} catch (RequestError e) {
+								throw e;
+							} catch (Exception) {
+								throw new RequestError (statusLine + " : " + error_message);
+							}
+						}
+
+						throw new RequestError (error_message, wex);
+					} else {
+						throw new RequestError ("Unable to contact server", wex);
+					}
 				}
 			
 				try {


### PR DESCRIPTION
`WebException.response` is null if the server is unreachable.  This PR updates the ToopherAPI request handler to correctly detect and return a well-behaved `RequestError` instead of just throwing a `NullReferenceException` when we attempt to access a field on `response`.
